### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/shiru2597/d50a687d-53d9-4860-a902-143a6f79f683/212cd303-798b-49f7-a7db-5643e0c9a76f/_apis/work/boardbadge/2c932dfa-5aed-4dec-8489-7515e6d7c515)](https://dev.azure.com/shiru2597/d50a687d-53d9-4860-a902-143a6f79f683/_boards/board/t/212cd303-798b-49f7-a7db-5643e0c9a76f/Microsoft.RequirementCategory)
 online-banking


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shiru2597/d50a687d-53d9-4860-a902-143a6f79f683/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.